### PR TITLE
Added support for multiple query parameters in URL

### DIFF
--- a/test.php
+++ b/test.php
@@ -1,3 +1,3 @@
 <?php
-header("Location: ".$_GET["endpoint"], true, 307);
+header("Location: ".substr($_SERVER['QUERY_STRING'],9), true, 307);
 ?>

--- a/ui.html
+++ b/ui.html
@@ -73,11 +73,11 @@ $( "#exec" ).click(function() {
 $( "embed" ).remove();
 //get URL and read parameters
 var url = new URL(window.location.href);
-var e = document.getElementById("endpoint").value;
-var r = document.getElementById("reqm").value;
-var c = document.getElementById("ctype").value;
-var d = document.getElementById("postdata").value;
-var p = document.getElementById("phpredir").value;
+var e = encodeURIComponent(document.getElementById("endpoint").value);
+var r = encodeURIComponent(document.getElementById("reqm").value);
+var c = encodeURIComponent(document.getElementById("ctype").value);
+var d = encodeURIComponent(document.getElementById("postdata").value);
+var p = encodeURIComponent(document.getElementById("phpredir").value);
 //create embed object, and call SWF with defined parameters
 var obj = document.createElement("embed");
 obj.src="test.swf?endpoint="+e+"&reqmethod="+r+"&ct="+c+"&jsonData="+d+"&php_url="+p;


### PR DESCRIPTION
Now supports URLs that have multiple parameters like the following:

`https://whatever/dothething?thing1=whatever&thing2=whatever_again`