### PR TITLE
feat: run swf_json_csrf as Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.4-cli
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN echo "" > index.html
+EXPOSE 8080
+CMD [ "php", "-S", "0.0.0.0:8080" ]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.3'
+services:
+  swf_json_csrf:
+    image: sp1d3r/swf_json_csrf
+    build: .
+    container_name: 'swf-json-csrf'
+    expose:
+      - "8080"
+


### PR DESCRIPTION
Run `swf_json_csrf` as a Docker container for easier deployment.